### PR TITLE
building: Add --compress-exclude option.

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -469,7 +469,15 @@ def __add_options(parser):
         "binaries during compression. FILE is the filename of the binary without path. This option can be used "
         "multiple times.",
     )
-
+    g.add_argument(
+        "--compress-exclude",
+        dest="compress_exclude",
+        metavar="FILE",
+        action="append",
+        help="Prevent a binary from being compressed during PKG creation."
+        "This is used when you want to include the binary image as is."
+        "FILE is the binary filename without path. This option can be used multiple times.",
+    )
     g = parser.add_argument_group('Windows and Mac OS X specific options')
     g.add_argument(
         "-c",
@@ -651,6 +659,7 @@ def main(
     strip=False,
     noupx=False,
     upx_exclude=None,
+    compress_exclude=None,
     runtime_tmpdir=None,
     contents_directory=None,
     pathex=[],
@@ -752,6 +761,7 @@ def main(
 
     hiddenimports = hiddenimports or []
     upx_exclude = upx_exclude or []
+    compress_exclude = compress_exclude or []
 
     # If file extension of the first script is '.pyw', force --windowed option.
     if is_win and os.path.splitext(scripts[0])[-1] == '.pyw':
@@ -802,6 +812,7 @@ def main(
         'strip': strip,
         'upx': not noupx,
         'upx_exclude': upx_exclude,
+        'compress_exclude': compress_exclude,
         'runtime_tmpdir': runtime_tmpdir,
         'exe_options': exe_options,
         # Directory with additional custom import hooks.

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -85,6 +85,7 @@ class BUNDLE(Target):
                 self.strip = arg.strip
                 self.upx = arg.upx
                 self.upx_exclude = arg.upx_exclude
+                self.compress_exclude = arg.compress_exclude
                 self.console = arg.console
                 self.target_arch = arg.target_arch
                 self.codesign_identity = arg.codesign_identity
@@ -96,6 +97,7 @@ class BUNDLE(Target):
                 self.strip = arg.strip_binaries
                 self.upx = arg.upx_binaries
                 self.upx_exclude = arg.upx_exclude
+                self.compress_exclude = arg.compress_exclude
                 self.console = arg.console
                 self.target_arch = arg.target_arch
                 self.codesign_identity = arg.codesign_identity
@@ -625,6 +627,7 @@ class BUNDLE(Target):
                     use_strip=self.strip,
                     use_upx=self.upx,
                     upx_exclude=self.upx_exclude,
+                    compress_exclude=self.compress_exclude,
                     target_arch=self.target_arch,
                     codesign_identity=self.codesign_identity,
                     entitlements_file=self.entitlements_file,

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -41,6 +41,7 @@ exe = EXE(
     strip=%(strip)s,
     upx=%(upx)s,
     upx_exclude=%(upx_exclude)s,
+    compress_exclude=%(compress_exclude)s,
     runtime_tmpdir=%(runtime_tmpdir)r,
     console=%(console)s,
     disable_windowed_traceback=%(disable_windowed_traceback)s,
@@ -92,6 +93,7 @@ coll = COLLECT(
     strip=%(strip)s,
     upx=%(upx)s,
     upx_exclude=%(upx_exclude)s,
+    compress_exclude=%(compress_exclude)s,
     name='%(name)s',
 )
 """

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -109,6 +109,7 @@ def process_collected_binary(
     use_strip=False,
     use_upx=False,
     upx_exclude=None,
+    compress_exclude=None,
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,


### PR DESCRIPTION
If a file is specified, that file will not be compressed. This is useful if you want to include a specific file in the EXE without compressing it.